### PR TITLE
ci: only allowed sonar job to read PRs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,9 +5,6 @@ on:
     branches: ["main"]
   pull_request:
 
-permissions:
-  pull-requests: read # allows SonarCloud to decorate PRs with analysis results
-
 jobs:
   build:
     strategy:
@@ -41,6 +38,8 @@ jobs:
     name: Run eslint and sonar scanning
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pull-requests: read # allows SonarCloud to decorate PRs with analysis results
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
# Please check before merging

- [x] Is the content of the `README.md` file still up-to-date?
- [ ] ~Have you added an entry to the `CHANGELOG.md`?~
- [x] Is the pull request title written in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?
- [ ] ~VSCode: Did you follow the [UX Guidelines](https://code.visualstudio.com/api/ux-guidelines/overview)?~

# Description

only allowed sonar job to read PRs in order to fix [githubactions:S8264](https://sonarcloud.io/organizations/aditosoftware/rules?open=githubactions%3AS8264&rule_key=githubactions%3AS8264)